### PR TITLE
Prefer SHA1 over MD5 MACs

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -112,10 +112,10 @@ class Transport (threading.Thread, ClosingContextManager):
     _preferred_macs = (
         'hmac-sha2-256',
         'hmac-sha2-512',
-        'hmac-md5',
         'hmac-sha1-96',
-        'hmac-md5-96',
         'hmac-sha1',
+        'hmac-md5',
+        'hmac-md5-96',
     )
     _preferred_keys = (
         'ssh-rsa',


### PR DESCRIPTION
When running with FIPS restricted OpenSSL, md5 will error.  A number of
endpoints do sha1, but not sha2.  Reordering the preference allows the client
to connect from such clients.
